### PR TITLE
oprava farbičkovania textu pre OpenPLi 8.1

### DIFF
--- a/build/plugin/src/converter/ACZSKKodiToE2List.py
+++ b/build/plugin/src/converter/ACZSKKodiToE2List.py
@@ -2,6 +2,18 @@ import re
 from Components.Converter.Converter import Converter
 from Components.Element import cached
 
+colorFixNeeded = True # old behaviour as default
+
+try:
+    from Tools.Hex2strColor import Hex2strColor
+    if Hex2strColor(0xffffffff) == "\c????????":
+        colorFixNeeded = True
+    else:
+        colorFixNeeded = False
+except:
+    pass
+
+
 def getEscapeColorFromHexString(color):
         if color.startswith('#'):
             color = color[1:]
@@ -10,6 +22,8 @@ def getEscapeColorFromHexString(color):
         if len(color) != 8:
             print 'invalid color %s'
             return getEscapeColorFromHexString("00ffffff")
+        if colorFixNeeded == False:
+            return color
         colorsarray = []
         for x in color:
             if x == "0":


### PR DESCRIPTION
V aktuálnom OpenPLi 8.1 došlo k zmene ako sa interpretujú kódy \cXXXXXXXX určené pre zmenu farieb v texte. Táto zmena spôsobila to, že akýkoľvek text označený ako Bold, Italic alebo konkrétnou farbou ([B], [I], [COLOR xxx]) je zobrazený čiernou farbou na čiernom pozadí. Táto úprava sa snaží rozpoznať starú/novú interpreráciu a podľa toho prispôsobuje výsledné farebné kódy. Bolo to odskúšané na OpenPLi 7.3 a OpenPLi 8.1.